### PR TITLE
Incorrect behavior in siftdown and siftup methods when dealing with a value of 0

### DIFF
--- a/src/heapq.ts
+++ b/src/heapq.ts
@@ -88,7 +88,7 @@ export class Heapq<T> {
 
     private siftdown(startPos: number, pos: number) {
         const newItem: T = this.heap[pos];
-        if (!newItem) {
+        if (newItem === undefined) {
             return;
         }
 
@@ -111,7 +111,7 @@ export class Heapq<T> {
         const endPos: number = this.heap.length;
         const startPos: number = pos;
         const newItem = this.heap[pos];
-        if (!newItem) {
+        if (newItem === undefined) {
             return;
         }
 

--- a/src/heapq_test.ts
+++ b/src/heapq_test.ts
@@ -47,4 +47,24 @@ describe("Heapq", () => {
         expect(maxHeap.top() === 15);
 
     });
+
+    test('should handle zero correctly', () => {
+        heap.push(5);
+        heap.push(3);
+        heap.push(0);
+
+        expect(heap.pop()).to.equal(0);
+        expect(heap.pop()).to.equal(3);
+        expect(heap.pop()).to.equal(5);
+    });
+
+    test('should handle multiple zeros correctly', () => {
+        heap.push(0);
+        heap.push(0);
+        heap.push(0);
+
+        expect(heap.pop()).to.equal(0);
+        expect(heap.pop()).to.equal(0);
+        expect(heap.pop()).to.equal(0);
+    });
 });


### PR DESCRIPTION
## Description:

In the current implementation of the Heapq class, both siftdown and siftup methods exhibit unexpected behavior when they encounter a value of 0.

## Details:

In the siftdown method:

```
const newItem: T = this.heap[pos];
if (!newItem) {
    return;
}
```

In the siftup method:

```
const newItem = this.heap[pos];
if (!newItem) {
    return;
}
```

For both methods, if newItem evaluates to 0, the function will prematurely exit. This is problematic especially when the type T is a number, as 0 is a valid value that might need to be added to the heap.

## Expected Behavior:

The methods should only exit prematurely if newItem is undefined.

## Suggested Fix:

Replace the checks in both methods with:

```
if (newItem === undefined) {
    return;
}
```
This ensures that the methods will work correctly even when they encounter a value of 0.

### Impact:

Incorrect handling of 0 can lead to unexpected behaviors and potentially incorrect results when using the heap operations.

